### PR TITLE
disabling Style/ClassAndModuleChildren

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -60,3 +60,7 @@ Style/SymbolArray:
 
 Style/WordArray:
   Enabled: false
+
+# We have deep modules so we don't want to waste the space.
+Style/ClassAndModuleChildren:
+  Enabled: false


### PR DESCRIPTION
Disables the Style ClassAndModuleChildren

rubocop default vs our usage

rubocop default

```
module A
  module B
    Class C # nested identation
    end
  end
end
```

our usage

```
module A::B
  Class C # just 1 identation
  end
end
```
